### PR TITLE
Revamp the settings system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	compile "com.badlogicgames.gdx:gdx-backend-lwjgl:1.9.4"
 	compile "com.badlogicgames.gdx:gdx-platform:1.9.4:natives-desktop"
 	compile "com.badlogicgames.gdx:gdx-freetype-platform:1.9.4:natives-desktop"
+
+	compile "ninja.leaping.configurate:configurate-hocon:3.1"
 }
 
 task fatJar(type: Jar) {

--- a/src/main/java/pw/lemmmy/jrogue/Settings.java
+++ b/src/main/java/pw/lemmmy/jrogue/Settings.java
@@ -1,16 +1,29 @@
 package pw.lemmmy.jrogue;
 
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
 public class Settings {
-	private String playerName;
-	
+	@Setting(comment="The name of the player as it appears in the game.")
+	private String playerName = System.getProperty("user.name");
+
+	@Setting(comment="The width of the game window.")
 	private int screenWidth = 800;
+	@Setting(comment="The height of the game window.")
 	private int screenHeight = 640;
-	
+
+	@Setting(comment="The size of the log.")
 	private int logSize = 7;
+	@Setting(comment="The scale of the HUD.")
 	private float hudScale = 1.0f;
+
+	@Setting(comment="The width of each individual tile (square) on the minimap.")
 	private int minimapTileWidth = 2;
+	@Setting(comment="The height of each individual tile (square) on the minimap.")
 	private int minimapTileHeight = 2;
-	
+
+	@Setting(comment="Whether to autosave the game.")
 	private boolean autosave = true;
 	
 	public String getPlayerName() {
@@ -30,59 +43,59 @@ public class Settings {
 		
 		this.playerName = playerName;
 	}
-	
+
 	public int getScreenWidth() {
 		return screenWidth;
 	}
-	
+
 	public void setScreenWidth(int screenWidth) {
 		this.screenWidth = screenWidth;
 	}
-	
+
 	public int getScreenHeight() {
 		return screenHeight;
 	}
-	
+
 	public void setScreenHeight(int screenHeight) {
 		this.screenHeight = screenHeight;
 	}
-	
+
 	public int getLogSize() {
 		return logSize;
 	}
-	
+
 	public void setLogSize(int logSize) {
 		this.logSize = logSize;
 	}
-	
+
 	public float getHUDScale() {
 		return hudScale;
 	}
-	
+
 	public void setHUDScale(float hudScale) {
 		this.hudScale = hudScale;
 	}
-	
-	public boolean autosave() {
+
+	public boolean shouldAutosave() {
 		return autosave;
 	}
-	
+
 	public void setAutosave(boolean autosave) {
 		this.autosave = autosave;
 	}
-	
+
 	public int getMinimapTileWidth() {
 		return minimapTileWidth;
 	}
-	
+
 	public void setMinimapTileWidth(int minimapTileWidth) {
 		this.minimapTileWidth = minimapTileWidth;
 	}
-	
+
 	public int getMinimapTileHeight() {
 		return minimapTileHeight;
 	}
-	
+
 	public void setMinimapTileHeight(int minimapTileHeight) {
 		this.minimapTileHeight = minimapTileHeight;
 	}

--- a/src/main/java/pw/lemmmy/jrogue/rendering/gdx/GDXRenderer.java
+++ b/src/main/java/pw/lemmmy/jrogue/rendering/gdx/GDXRenderer.java
@@ -18,7 +18,6 @@ import pw.lemmmy.jrogue.Settings;
 import pw.lemmmy.jrogue.dungeon.Dungeon;
 import pw.lemmmy.jrogue.dungeon.Level;
 import pw.lemmmy.jrogue.dungeon.entities.Entity;
-import pw.lemmmy.jrogue.dungeon.entities.player.Player;
 import pw.lemmmy.jrogue.rendering.Renderer;
 import pw.lemmmy.jrogue.rendering.gdx.entities.EntityMap;
 import pw.lemmmy.jrogue.rendering.gdx.entities.EntityPooledEffect;
@@ -559,7 +558,7 @@ public class GDXRenderer extends ApplicationAdapter implements Renderer, Dungeon
 	public void dispose() {
 		super.dispose();
 		
-		if (settings.autosave() && !dontSave && dungeon.getPlayer().isAlive()) {
+		if (settings.shouldAutosave() && !dontSave && dungeon.getPlayer().isAlive()) {
 			dungeon.save();
 		}
 		


### PR DESCRIPTION
Settings files now use HOCON, which looks like this:
```
settings {
    # Whether to autosave the game.
    autosave=true
    # The scale of the HUD.
    hudScale=1
    # The size of the log.
    logSize=7
    # The height of each individual tile (square) on the minimap.
    minimapTileHeight=4
    # The width of each individual tile (square) on the minimap.
    minimapTileWidth=4
    # The name of the player as it appears in the game.
    playerName=Debugger
    # The height of the game window.
    screenHeight=640
    # The width of the game window.
    screenWidth=800
}
```

This is done with a fancy library called Configurate. I set up the `Settings` class like this:
```
@ConfigSerializable
public class Settings {
	@Setting(comment="The name of the player as it appears in the game.")
	private String playerName = System.getProperty("user.name");

	@Setting(comment="The width of the game window.")
	private int screenWidth = 800;
	@Setting(comment="The height of the game window.")
	private int screenHeight = 640;

        // ... Rest of the code
}
```

Which allows me to easily store it in a config file:
```
root = loader.load();

if (root.getNode("settings").isVirtual()) {
	root.getNode("settings").setValue(TypeToken.of(Settings.class), new Settings());
	loader.save(root);
}

settings = root.getNode("settings").getValue(TypeToken.of(Settings.class));
```

There are certainly better ways in which we can exploit this infrastructure. Perhaps we could have a `DisplaySettings` and a `PlayerSettings` class, which would allow us to split the config file up into different categories, as well as having nicer code.

I wasn't able to fix the getter/setter hell with this; I'm not entirely sure how to approach it. Though, one option is to just do away with them completely and directly reference the class attributes. A bit unconventional, but it's Java, anything works.

Some things to note:
- This will create a default config, unlike the previous system. Thus, we might wanna move the file to `~/.config/jrogue.cfg` or something, since we don't wanna pollute the home directory. I could also change this behaviour, but I like having the comments.
- Our INI library is now unused. Shall we remove it?
- The config comments may not be accurate, so please review those carefully.