### PR TITLE
Fix thermometers not measuring temperature in sewers

### DIFF
--- a/src/main/java/jr/dungeon/items/valuables/ItemThermometer.java
+++ b/src/main/java/jr/dungeon/items/valuables/ItemThermometer.java
@@ -40,7 +40,9 @@ public class ItemThermometer extends Item implements Readable, Shatterable {
 			case COLD:
 				reader.getDungeon().The("mercury is packed into the bottom of the thermometer!");
 				break;
-			case LIMBO:
+			case MID:
+				reader.getDungeon().The("mercury reaches up to a quarter of the thermometer.");
+				break;
 			case WARM:
 				reader.getDungeon().The("mercury fills about half of the thermometer.");
 				break;


### PR DESCRIPTION
This is because there was no message defined for `Climate.MID`. Perhaps we should make the message an enum constructor parameter to ensure that every climate has one?